### PR TITLE
Fix: Correct FLASK_APP for Superset service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       SUPERSET_LOAD_EXAMPLES: "false" # Don't load example data/dashboards
       # For Superset to initialize itself and create tables in its metadata DB
       # These are often needed for the entrypoint script of the official image
-      FLASK_APP: "superset" 
+      FLASK_APP: "superset.app:create_app()" 
       # Superset can use a Postgres DB for its own metadata.
       # For simplicity here, we'll let it use its default SQLite within a volume.
       # To use our existing Postgres instance for Superset's metadata (more robust):


### PR DESCRIPTION
The Superset container (etl_superset) was failing to start due to Gunicorn not being able to find the WSGI application object. The error log showed: "Failed to find attribute 'application' in 'superset'".

This was caused by the FLASK_APP environment variable being set to "superset", which led Gunicorn to look for an 'application' attribute directly in the 'superset' module.

The fix involves changing FLASK_APP to "superset.app:create_app()". This directs Gunicorn to use the standard application factory pattern employed by Superset, allowing it to correctly load the application. This is the common way to configure the official apache/superset Docker image.